### PR TITLE
Fill all outlines and hide metrics

### DIFF
--- a/DragToKern.glyphsTool/Contents/Resources/plugin.py
+++ b/DragToKern.glyphsTool/Contents/Resources/plugin.py
@@ -227,6 +227,13 @@ class DragToKern(SelectTool):
             kerning,
         )
 
+    def drawLayer_atPoint_asActive_attributes_(self, layer, layerOrigin, active, attributes):
+        gv = self.editViewController().graphicView()
+        gv.drawLayer_atPoint_asActive_attributes_(layer, layerOrigin, active, attributes)
+
+    def drawMetricsForLayer_atPoint_asActive_(self, layer, layerOrigin, active):
+        pass
+
     @objc.python_method
     def __file__(self):
         """Please leave this method unchanged"""


### PR DESCRIPTION
This change fills the outline for the active layer in addition to the inactive layers and hides the metrics of the active layer.

The code change should be mostly self-explanatory, with `drawLayer_atPoint_asActive_attributes_` now using the default layer-drawing implementation of the graphics view and `drawMetricsForLayer_atPoint_asActive_` now doing nothing. If you want to keep the metrics, you can also just partially accept this pull request.