### PR TITLE
Allow to quickly jump back to the Select tool

### DIFF
--- a/DragToKern.glyphsTool/Contents/Resources/plugin.py
+++ b/DragToKern.glyphsTool/Contents/Resources/plugin.py
@@ -5,6 +5,7 @@ import objc
 
 from AppKit import (
     NSBezierPath,
+    NSClassFromString,
     NSColor,
     NSCursor,
     NSFont,
@@ -12,6 +13,7 @@ from AppKit import (
     NSFontWeightRegular,
     NSForegroundColorAttributeName,
     NSGradient,
+    NSNotFound,
     NSPoint,
     NSRect,
     NSString,
@@ -24,6 +26,7 @@ except:
     from GlyphsApp import LTR, RTL
 from GlyphsApp.plugins import SelectTool
 
+GlyphsToolSelect = NSClassFromString("GlyphsToolSelect")
 
 DRAW_LABELS = False
 LIVE_UPDATE = True
@@ -106,6 +109,13 @@ class DragToKern(SelectTool):
         Get the mouse down location to record the start coordinate and dragged
         layer.
         """
+        if theEvent.clickCount() == 2:
+            wc = self.windowController()
+            wc.setToolForClass_(GlyphsToolSelect)
+            toolDelegate = wc.toolEventDelegate()
+            if toolDelegate.respondsToSelector_("selectGlyph:"):
+                toolDelegate.selectGlyph_(theEvent)
+            return
         # Get the mouse click location and convert it to local coordinates
         evc = self.editViewController()
         gv = evc.graphicView()
@@ -179,6 +189,10 @@ class DragToKern(SelectTool):
             self.layer2 = composedLayers[layerIndex]
 
         self.layer2.parent.beginUndo()
+
+    def cancelOperation_(self, sender):
+        wc = self.windowController()
+        wc.setToolForClass_(GlyphsToolSelect)
 
     @objc.python_method
     def cancel_operation(self):

--- a/DragToKern.glyphsTool/Contents/Resources/plugin.py
+++ b/DragToKern.glyphsTool/Contents/Resources/plugin.py
@@ -13,7 +13,6 @@ from AppKit import (
     NSFontWeightRegular,
     NSForegroundColorAttributeName,
     NSGradient,
-    NSNotFound,
     NSPoint,
     NSRect,
     NSString,


### PR DESCRIPTION
This change adds support for double-clicking a glyph or pressing the Escape key to activate the Select tool.

You could also consider changing it such that double-clicking just select a different layer, but does not switch to the Select tool, like so:

```python
        if theEvent.clickCount() == 2:
            self.selectGlyph_(theEvent)
            return
```